### PR TITLE
Add Readme and guide documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# Pong Test Run
+
+Required Software:
+[Godot v4.4.1](https://godotengine.org/download/)
+
+### Guides:
+
+:closed_book: [Beginner Guide to Godot and Git](https://blog.paulhartman.dev/100-dev-setup)
+
+:closed_book: [From task assignment to integration](docs/coding_guide.md)
+
+:closed_book: [Contributors Guide](docs/contributing.md) [ [TL;DR](docs/contributing_tldr.md) ]

--- a/docs/coding_guide.md
+++ b/docs/coding_guide.md
@@ -1,0 +1,39 @@
+### 1. [DISCORD]
+Find yourself a task that you would like to work on today
+
+### 2. [DISCORD]
+Let everyone know that you picked it, so that other people dont work on the same thing
+
+### 3. [YOUR HEAD]
+a. With the goal in mind make a rough plan on how you can approach the task at hand\
+b. If you are unsure at this point, ask someone in your team for their opinion
+
+### 4. [GIT]
+Fetch any new changes from the remote repo, add a new branch from "main", and name according to your teams convention
+
+### 5. [GODOT / IDE] 
+a. Implement ALL of the changes mentioned in the task\
+b. Keep the code readable for other people , variable and function names do not need to be short\
+c. Use multiple script files to keep unrelated logic apart\
+d. Check if the project runs\
+e. Test if your changes work as intended\
+f. Test ( within reason ) if the game overall didn't break
+		
+### 6. [GIT]
+a. Commit ALL of the changes you made to your branch\
+b. Push your branch to the remote repo\
+c. If there have been changes on the "main" in the meantime merge it into your branch\
+d. If there are any merge conflicts, resolve them, commit, and push to the remote repo again
+
+### 7. [GITHUB]
+Create a new pull request, merging your new branch into the "main" branch
+	
+### 8. [DISCORD]
+Inform others of your progress
+	
+### 9. [TRIGGER]
+When your pull request gets reviewed, and there are some comments:
+
+a. If you feel the reviewer is right, implement the changes, and go back to 5.d.\
+b. If you feel the reviewer is in the wrong, ask another member of your team for feedback
+		

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,147 @@
+# Contributing Guidelines
+
+*Pull requests, bug reports, and all other forms of contribution are welcomed and highly encouraged!* :octocat:
+
+### Contents
+
+- [Opening an Issue](#inbox_tray-opening-an-issue)
+- [Triaging Issues](#mag-triaging-issues)
+- [Submitting Pull Requests](#repeat-submitting-pull-requests)
+- [Writing Commit Messages](#memo-writing-commit-messages)
+- [Code Review](#white_check_mark-code-review)
+- [Coding Style](#nail_care-coding-style)
+- [Certificate of Origin](#medal_sports-certificate-of-origin)
+- [Credits](#pray-credits)
+
+> **This guide serves to set clear expectations for everyone involved with the project so that we can improve it together while also creating a welcoming space for everyone to participate. Following these guidelines will help ensure a positive experience for contributors and maintainers.**
+
+## :inbox_tray: Opening an Issue
+
+Before [creating an issue](https://help.github.com/en/github/managing-your-work-on-github/creating-an-issue), check if you are using the latest version of the project. If you are not up-to-date, see if updating fixes your issue first.
+
+### :beetle: Bug Reports and Other Issues
+
+A great way to contribute to the project is to send a detailed issue when you encounter a problem. We always appreciate a well-written, thorough bug report. :v:
+
+In short, since you are most likely a developer, **provide a ticket that you would like to receive**.
+
+- **Review the documentation** before opening a new issue.  :construction: ( WILL THERE BE DOCUMENTATION? )
+
+- **Do not open a duplicate issue!** Search through existing issues to see if your issue has previously been reported. If your issue exists, comment with any additional information you have. You may simply note "I have this problem too", which helps prioritize the most common problems and requests. 
+
+- **Prefer using [reactions](https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/)**, not comments, if you simply want to "+1" an existing issue.
+
+- **Fully complete the provided issue template.** The bug report template requests all the information we need to quickly and efficiently address your issue. Be clear, concise, and descriptive. Provide as much information as you can, including steps to reproduce, stack traces, compiler errors, library versions, OS versions, and screenshots (if applicable).
+
+- **Use [GitHub-flavored Markdown](https://help.github.com/en/github/writing-on-github/basic-writing-and-formatting-syntax).** Especially put code blocks and console outputs in backticks (```). This improves readability.
+
+## :mag: Triaging Issues
+
+You can triage issues which may include reproducing bug reports or asking for additional information, such as version numbers or reproduction instructions. Any help you can provide to quickly resolve an issue is very much appreciated!
+
+## :repeat: Submitting Pull Requests
+
+We **love** pull requests! Before [forking the repo](https://help.github.com/en/github/getting-started-with-github/fork-a-repo) and [creating a pull request](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/proposing-changes-to-your-work-with-pull-requests) for non-trivial changes, it is usually best to first open an issue to discuss the changes, or discuss your intended approach for solving the problem in the comments for an existing issue.
+
+For most contributions, after your first pull request is accepted and merged, you will be [invited to the project](https://help.github.com/en/github/setting-up-and-managing-your-github-user-account/inviting-collaborators-to-a-personal-repository) and given **push access**. :tada:
+
+*Note: All contributions will be licensed under the project's license.*
+
+- **Smaller is better.** Submit **one** pull request per bug fix or feature. A pull request should contain isolated changes pertaining to a single bug fix or feature implementation. **Do not** refactor or reformat code that is unrelated to your change. It is better to **submit many small pull requests** rather than a single large one. Enormous pull requests will take enormous amounts of time to review, or may be rejected altogether. 
+
+- **Coordinate bigger changes.** For large and non-trivial changes, open an issue to discuss a strategy with the maintainers. Otherwise, you risk doing a lot of work for nothing!
+
+- **Prioritize understanding over cleverness.** Write code clearly and concisely. Remember that source code usually gets written once and read often. Ensure the code is clear to the reader. The purpose and logic should be obvious to a reasonably skilled developer, otherwise you should add a comment that explains it.
+
+- **Follow existing coding style and conventions.** Keep your code consistent with the style, formatting, and conventions in the rest of the code base. When possible, these will be enforced with a linter. Consistency makes it easier to review and modify in the future.
+
+- **Include test coverage.** Add unit tests or UI tests when possible. Follow existing patterns for implementing tests.
+
+- **Update the example project** if one exists to exercise any new functionality you have added.
+
+- **Add documentation.** Document your changes with code doc comments or in existing guides. :construction:( APPLIES TO US? )
+
+- **Update the CHANGELOG** for all enhancements and bug fixes. Include the corresponding issue number if one exists, and your GitHub username. (example: "- Fixed crash in profile view. #123 @jessesquires")
+
+- **Use the repo's default branch.** Branch from and [submit your pull request](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request-from-a-fork) to the repo's default branch. Usually this is `main`, but it could be `dev`, `develop`, or `master`. :construction: ( WE BRANCH FROM MAIN BUT SUMBIT TO TEAM BRANCH? )
+
+- **[Resolve any merge conflicts](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/resolving-a-merge-conflict-on-github)** that occur.
+
+- **Promptly address any CI failures**. If your pull request fails to build or pass tests, please push another commit to fix it. 
+
+- When writing comments, use properly constructed sentences, including punctuation.
+
+- Use spaces, not tabs.
+
+## :memo: Writing Commit Messages
+
+Please [write a great commit message](https://chris.beams.io/posts/git-commit/).
+
+1. Separate subject from body with a blank line
+1. Limit the subject line to 50 characters
+1. Capitalize the subject line
+1. Do not end the subject line with a period
+1. Use the imperative mood in the subject line (example: "Fix networking issue")
+1. Wrap the body at about 72 characters
+1. Use the body to explain **why**, *not what and how* (the code shows that!)
+1. If applicable, prefix the title with the relevant component name. (examples: "[Docs] Fix typo", "[Profile] Fix missing avatar") :construction: ( WILL WE HAVE TAGS? )
+
+```
+[TAG] Short summary of changes in 50 chars or less
+
+Add a more detailed explanation here, if necessary. Possibly give 
+some background about the issue being fixed, etc. The body of the 
+commit message can be several paragraphs. Further paragraphs come 
+after blank lines and please do proper word-wrap.
+
+Wrap it to about 72 characters or so. In some contexts, 
+the first line is treated as the subject of the commit and the 
+rest of the text as the body. The blank line separating the summary 
+from the body is critical (unless you omit the body entirely); 
+various tools like `log`, `shortlog` and `rebase` can get confused 
+if you run the two together.
+
+Explain the problem that this commit is solving. Focus on why you
+are making this change as opposed to how or what. The code explains 
+how or what. Reviewers and your future self can read the patch, 
+but might not understand why a particular solution was implemented.
+Are there side effects or other unintuitive consequences of this
+change? Here's the place to explain them.
+
+ - Bullet points are okay, too
+
+ - A hyphen or asterisk should be used for the bullet, preceded
+   by a single space, with blank lines in between
+
+Note the fixed or relevant GitHub issues at the end:
+
+Resolves: #123
+See also: #456, #789
+```
+
+## :white_check_mark: Code Review
+
+- **Review the code, not the author.** Look for and suggest improvements without disparaging or insulting the author. Provide actionable feedback and explain your reasoning.
+
+- **You are not your code.** When your code is critiqued, questioned, or constructively criticized, remember that you are not your code. Do not take code review personally.
+
+- **Always do your best.** No one writes bugs on purpose. Do your best, and learn from your mistakes.
+
+- Kindly note any violations to the guidelines specified in this document. 
+
+## :nail_care: Coding Style
+
+Consistency is the most important. Following the existing style, formatting, and naming conventions of the file you are modifying and of the overall project. Failure to do so will result in a prolonged review process that has to focus on updating the superficial aspects of your code, rather than improving its functionality and performance.
+
+When possible, style and format will be enforced with a linter.
+
+## :medal_sports: Certificate of Origin :construction: ( LEAVE THAT IN HERE AS IS? )
+
+*Developer's Certificate of Origin 1.1*
+
+By making a contribution to this project, I certify that:
+
+> 1. The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or
+> 1. The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or
+> 1. The contribution was provided directly to me by some other person who certified (1), (2) or (3) and I have not modified it.
+> 1. I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.

--- a/docs/contributing_tldr.md
+++ b/docs/contributing_tldr.md
@@ -1,0 +1,34 @@
+# 🧠 TL;DR: Contributing Guide for Beginners
+
+## :inbox_tray: Opening an Issue
+
+- Use the latest version of the main branch before reporting.
+- Search existing issues to avoid duplicates.
+- Format your code with `` backticks. One for a line, 3 for a block
+  
+`Codeline`
+
+```
+Code
+block
+```
+
+## :repeat: Submitting Pull Requests
+
+- Submit **small, focused** PRs.
+- Don't refactor unrelated code.
+- Discuss big changes first.
+- If necessary update tests.
+- Fix any CI/test failures ASAP, you may have to wait for all automated test actions to complete.
+
+## :memo: Commits
+
+- We never commit to the `main` branch directly.
+- Subject line: 50 chars max, capitalized, no period, imperative: "Fix bug", not "Fixes bug" or "Fixed bug".
+- Leave a blank line between subject and body. Most GUIs will do that automatically.
+- Use the body and explain **why** in the body, not just **what**.
+
+## :nail_care: Coding Style
+
+- Follow the [official GDScript styleguide](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_styleguide.html)
+- Use spaces for indentation, not tabs.


### PR DESCRIPTION
Adds a short README draft. Adds guide documents that will still need to be reviewed, corrected or re-designed.

I left 🚧 signs with questions in `contributing.md`.