### PR TITLE
Add git lfs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,22 @@
 # Normalize EOL for all files that Git considers text files.
 * text=auto eol=lf
+# Compiled libraries (e.g from gdextensions)
+*.dll filter=lfs diff=lfs merge=lfs -text
+*.so filter=lfs diff=lfs merge=lfs -text
+*.dylib filter=lfs diff=lfs merge=lfs -text
+# Executables
+*.exe filter=lfs diff=lfs merge=lfs -text
+# Art
+*.png filter=lfs diff=lfs merge=lfs -text
+*.jpg filter=lfs diff=lfs merge=lfs -text
+*.jpeg filter=lfs diff=lfs merge=lfs -text
+*.ttf filter=lfs diff=lfs merge=lfs -text
+*.svg filter=lfs diff=lfs merge=lfs -text
+*.blend filter=lfs diff=lfs merge=lfs -text
+*.obj filter=lfs diff=lfs merge=lfs -text
+*.fbx filter=lfs diff=lfs merge=lfs -text
+# Audio
+*.mp3 filter=lfs diff=lfs merge=lfs -text
+*.wav filter=lfs diff=lfs merge=lfs -text
+*.ogg filter=lfs diff=lfs merge=lfs -text
+*.flac filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
I added a bunch of default file formats we might want in the future, and we can add more later on if they come up? e.g from FMOD

to use git-lfs, make sure:
1. you install git lfs https://git-lfs.com/
2. you run the install command `git lfs install` once on your machine, so it can modify your git to interact with lfs stuff
3. that's it, clone and pull the repo like normal and use normal git commands

if you find binary files on your system end up as small text files, then git-lfs hasn't been set up properly on your machine

Closes https://github.com/100-Devs-1-Game/Pong-Test-Run/issues/9