### PR TITLE
mark additional large binary files as lfs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,8 +2,14 @@
 * text=auto eol=lf
 # Compiled libraries (e.g from gdextensions)
 *.dll filter=lfs diff=lfs merge=lfs -text
+*.lib filter=lfs diff=lfs merge=lfs -text
 *.so filter=lfs diff=lfs merge=lfs -text
+*.so.14 filter=lfs diff=lfs merge=lfs -text
+*.so.14.6 filter=lfs diff=lfs merge=lfs -text
+*.wasm filter=lfs diff=lfs merge=lfs -text
 *.dylib filter=lfs diff=lfs merge=lfs -text
+*.template_debug filter=lfs diff=lfs merge=lfs -text
+*.a filter=lfs diff=lfs merge=lfs -text
 # Executables
 *.exe filter=lfs diff=lfs merge=lfs -text
 # Art


### PR DESCRIPTION
Found some more large 1 MB+ files that we may be able to mark as LFS files.

<img width="759" height="513" alt="Screenshot from 2025-07-18 13-00-44" src="https://github.com/user-attachments/assets/9e37839a-bba4-4eaa-a502-004316539411" />
<img width="759" height="513" alt="Screenshot from 2025-07-18 13-01-39" src="https://github.com/user-attachments/assets/252e059e-866b-4618-b54f-e893d4d44721" />
<img width="759" height="513" alt="Screenshot from 2025-07-18 13-03-47" src="https://github.com/user-attachments/assets/0317c0c4-9071-44fe-a653-b38eecfda64e" />
