### PR TITLE
GitIgnore files prefixed with '~'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Temp files
+~*
+
 # Godot 4+ specific ignores
 .godot/
 .nomedia


### PR DESCRIPTION
Godot seems to create some temp files prefixed with ~, usually of a DLL, this will keep it out of the repo

https://discord.com/channels/1393033395298373643/1394701984707248189/1395842254500925500